### PR TITLE
Ck/sinope dimmer 201912

### DIFF
--- a/bundles/org.openhab.binding.sinope/README.md
+++ b/bundles/org.openhab.binding.sinope/README.md
@@ -6,9 +6,11 @@ This binding supports multiple gateways with multiple devices.
 
 ## Supported Things
 
-The Sinopé bridge is required as a "bridge" for accessing any other Sinopé devices.
+The Sinopé GT125 bridge is required as a "bridge" for accessing any other Sinopé devices.
 
-Right now, only the thermostat devices (3000W and 4000W) (TH1120RF) are supported.
+Right now, the following devices are supported:
+- Thermostats (3000W and 4000W) (TH1120RF) 
+- Dimmers and Switches (DM2500RF and SW2500RF). Note: Switches are handled as a dimmer that can have only two intensities: 0 (OFF) or 100 (ON).
 
 ## Discovery
 
@@ -87,6 +89,7 @@ The devices are identified by the ids that a Sinopé device returns when you hav
 
 ```
 thermostat room [ deviceId = "0x00 0x00 0x35 0x86" ]
+dimmer room [ deviceId = "0x00 0x00 0x35 0x87" ]
 ```
 
 ## Channels
@@ -101,6 +104,13 @@ Thermostat devices support some of the following channels:
  setpointMode        | String (RW) | Thermostat set point mode                                                                                                              |     
  heatingLevel        | Number (R)  | Heating Level                                                                                                                             | 
 
+Dimmer/Switch devices support the following channels:
+
+ Channel Type ID         | Item Type   | Description                                                                                                                            
+-------------------------|-------------|------------------------------------------------------------------------------------------------------------------------------------|
+ dimmerOutputIntensity   | Number (RW) | Output Intensity (0 = OFF, 100 = Full Intensity). For switches, 0 = OFF, 100 = ON                                                  |   
+
+
 ## Full Example
 
 In this example setup the Sinopé Gateway is represented as a Bridge **Home** with thermostat **Room**
@@ -110,6 +120,7 @@ In this example setup the Sinopé Gateway is represented as a Bridge **Home** wi
 ```
 Bridge sinope:gateway:home [ hostname="sinope", gatewayId="1234-4567-1234-1234", apiKey="0x12 0x34 0x56 0x78 0x9A 0xBC 0xDE 0xF0"] {
   thermostat room [ deviceId = "00003586" ]
+  dimmer room [ deviceId = "00003587" ]
 }
 ```
 
@@ -121,6 +132,8 @@ Number Room_Out "Outside Temp. [%.2f °C]" <temperature> { channel="sinope:therm
 Number Room_SetPoint "Room Set Point [%.2f °C]" <temperature> { channel="sinope:thermostat:home:room:setpointTemperature" }
 Number Room_SetPointMode "Room Set Point Mode" { channel="sinope:thermostat:home:room:setpointMode" }
 Number Room_HeatLevel "Room Heating level [%d]" <heating> { channel="sinope:thermostat:home:room:heatingLevel" }
+
+Number Room_Dimmer_OutputIntensity "Dimmer Output Intensity [%d] %%" <light> { channel="sinope:dimmer:home:room:dimmerOutputIntensity" }
 ```
 
 ### demo.sitemap:
@@ -134,6 +147,8 @@ sitemap demo label="Main Menu"
      Setpoint item=Room_SetPoint  label="Set Point [%.1f °C]" step=0.5 minValue=5 maxValue=35
      Switch item=Room_SetPointMode mappings=[2=Manual, 3=Auto, 5=Away]
      Slider item=Room_HeatLevel
+
+     Slider item=Room_Dimmer_OutputIntensity label="Dimmer Ouput Intensity"
   }
 }
 ```

--- a/bundles/org.openhab.binding.sinope/README.md
+++ b/bundles/org.openhab.binding.sinope/README.md
@@ -106,9 +106,10 @@ Thermostat devices support some of the following channels:
 
 Dimmer/Switch devices support the following channels:
 
- Channel Type ID         | Item Type   | Description                                                                                                                            
--------------------------|-------------|------------------------------------------------------------------------------------------------------------------------------------|
- dimmerOutputIntensity   | Number (RW) | Output Intensity (0 = OFF, 100 = Full Intensity). For switches, 0 = OFF, 100 = ON                                                  |   
+ Channel Type ID         | Item Type   | Description                                                                                                                                                                                                   |
+-------------------------|-------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+ dimmerOutputIntensity   | Number (RW) | Output Intensity (0 = OFF, 100 = Full Intensity). For switches, 0 = OFF, 100 = ON                                                                                                                             |   
+ lightMode               | Number (RW) | Light Mode (1 = Manual (Hold), 2 = Auto (Schedule), 3 = Random (Simulation of presence), 130 = Bypass Auto (Temporary hold until the next scheduled period)                                                   |    
 
 
 ## Full Example
@@ -134,6 +135,7 @@ Number Room_SetPointMode "Room Set Point Mode" { channel="sinope:thermostat:home
 Number Room_HeatLevel "Room Heating level [%d]" <heating> { channel="sinope:thermostat:home:room:heatingLevel" }
 
 Number Room_Dimmer_OutputIntensity "Dimmer Output Intensity [%d] %%" <light> { channel="sinope:dimmer:home:room:dimmerOutputIntensity" }
+Number Room_Dimmer_LightMode "Dimmer Light Mode [%d] <light> { channel="sinope:dimmer:home:room:lightMode" }
 ```
 
 ### demo.sitemap:
@@ -149,6 +151,7 @@ sitemap demo label="Main Menu"
      Slider item=Room_HeatLevel
 
      Slider item=Room_Dimmer_OutputIntensity label="Dimmer Ouput Intensity"
+     Switch item=Room_Dimmer_LightMode label="Dimmer Light Mode" mappings=[1=Manual, 2=Auto, 3=Random, 130=BypassAuto]
   }
 }
 ```

--- a/bundles/org.openhab.binding.sinope/README.md
+++ b/bundles/org.openhab.binding.sinope/README.md
@@ -114,14 +114,14 @@ Dimmer/Switch devices support the following channels:
 
 ## Full Example
 
-In this example setup the Sinopé Gateway is represented as a Bridge **Home** with thermostat **Room**
+In this example setup the Sinopé Gateway is represented as a Bridge **Home** with thermostat **Room** and dimmer "RoomDimmer"
 
 ### demo.things:
 
 ```
 Bridge sinope:gateway:home [ hostname="sinope", gatewayId="1234-4567-1234-1234", apiKey="0x12 0x34 0x56 0x78 0x9A 0xBC 0xDE 0xF0"] {
   thermostat room [ deviceId = "00003586" ]
-  dimmer room [ deviceId = "00003587" ]
+  dimmer roomdimmer [ deviceId = "00003587" ]
 }
 ```
 
@@ -134,8 +134,8 @@ Number Room_SetPoint "Room Set Point [%.2f °C]" <temperature> { channel="sinope
 Number Room_SetPointMode "Room Set Point Mode" { channel="sinope:thermostat:home:room:setpointMode" }
 Number Room_HeatLevel "Room Heating level [%d]" <heating> { channel="sinope:thermostat:home:room:heatingLevel" }
 
-Number Room_Dimmer_OutputIntensity "Dimmer Output Intensity [%d] %%" <light> { channel="sinope:dimmer:home:room:dimmerOutputIntensity" }
-Number Room_Dimmer_LightMode "Dimmer Light Mode [%d] <light> { channel="sinope:dimmer:home:room:lightMode" }
+Number Room_Dimmer_OutputIntensity "Dimmer Output Intensity [%d] %%" <light> { channel="sinope:dimmer:home:roomdimmer:dimmerOutputIntensity" }
+Number Room_Dimmer_LightMode "Dimmer Light Mode [%d] <light> { channel="sinope:dimmer:home:roomdimmer:lightMode" }
 ```
 
 ### demo.sitemap:

--- a/bundles/org.openhab.binding.sinope/src/main/java/org/openhab/binding/sinope/SinopeBindingConstants.java
+++ b/bundles/org.openhab.binding.sinope/src/main/java/org/openhab/binding/sinope/SinopeBindingConstants.java
@@ -42,6 +42,7 @@ public class SinopeBindingConstants {
     public final static String CHANNEL_OUTTEMP = "outsideTemperature";
 
     public final static String CHANNEL_DIMMER_OUTPUTINTENSITY = "dimmerOutputIntensity";
+    public static final String CHANNEL_LIGHTMODE = "lightMode";
 
     public static final String CONFIG_PROPERTY_HOST = "ipAddress";
     public static final String CONFIG_PROPERTY_PORT = "ipPort";

--- a/bundles/org.openhab.binding.sinope/src/main/java/org/openhab/binding/sinope/SinopeBindingConstants.java
+++ b/bundles/org.openhab.binding.sinope/src/main/java/org/openhab/binding/sinope/SinopeBindingConstants.java
@@ -32,6 +32,7 @@ public class SinopeBindingConstants {
     // List of all Thing Type UIDs
     public final static ThingTypeUID THING_TYPE_THERMO = new ThingTypeUID(BINDING_ID, "thermostat");
     public final static ThingTypeUID THING_TYPE_GATEWAY = new ThingTypeUID(BINDING_ID, "gateway");
+    public final static ThingTypeUID THING_TYPE_DIMMER = new ThingTypeUID(BINDING_ID, "dimmer");
 
     // List of all Channel ids
     public final static String CHANNEL_HEATINGLEVEL = "heatingLevel";
@@ -39,6 +40,8 @@ public class SinopeBindingConstants {
     public final static String CHANNEL_SETMODE = "setpointMode";
     public final static String CHANNEL_INTEMP = "insideTemperature";
     public final static String CHANNEL_OUTTEMP = "outsideTemperature";
+
+    public final static String CHANNEL_DIMMER_OUTPUTINTENSITY = "dimmerOutputIntensity";
 
     public static final String CONFIG_PROPERTY_HOST = "ipAddress";
     public static final String CONFIG_PROPERTY_PORT = "ipPort";
@@ -52,6 +55,7 @@ public class SinopeBindingConstants {
     static {
         SUPPORTED_THING_TYPES_UIDS.add(THING_TYPE_GATEWAY);
         SUPPORTED_THING_TYPES_UIDS.add(THING_TYPE_THERMO);
+        SUPPORTED_THING_TYPES_UIDS.add(THING_TYPE_DIMMER);
     }
 
 }

--- a/bundles/org.openhab.binding.sinope/src/main/java/org/openhab/binding/sinope/handler/SinopeDimmerHandler.java
+++ b/bundles/org.openhab.binding.sinope/src/main/java/org/openhab/binding/sinope/handler/SinopeDimmerHandler.java
@@ -1,0 +1,168 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.sinope.handler;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
+import org.eclipse.smarthome.config.core.Configuration;
+import org.eclipse.smarthome.core.library.types.QuantityType;
+import org.eclipse.smarthome.core.library.unit.SmartHomeUnits;
+import org.eclipse.smarthome.core.thing.*;
+import org.eclipse.smarthome.core.thing.binding.BaseThingHandler;
+import org.eclipse.smarthome.core.types.Command;
+import org.openhab.binding.sinope.SinopeBindingConstants;
+import org.openhab.binding.sinope.internal.config.SinopeConfig;
+import org.openhab.binding.sinope.internal.core.SinopeDataReadRequest;
+import org.openhab.binding.sinope.internal.core.SinopeDataWriteRequest;
+import org.openhab.binding.sinope.internal.core.appdata.SinopeOutputIntensityData;
+import org.openhab.binding.sinope.internal.core.base.SinopeDataAnswer;
+import org.openhab.binding.sinope.internal.util.ByteUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.UnknownHostException;
+
+/**
+ * The {@link SinopeDimmerHandler} is responsible for handling commands, which are
+ * sent to one of the channels.
+ *
+ * @author Christos Karras - Initial contribution
+ */
+@NonNullByDefault
+public class SinopeDimmerHandler extends BaseThingHandler {
+
+    private static final int DATA_ANSWER = 0x0A;
+
+    private Logger logger = LoggerFactory.getLogger(SinopeDimmerHandler.class);
+
+    private byte[] deviceId = new byte[0];
+
+    public SinopeDimmerHandler(Thing thing) {
+        super(thing);
+    }
+
+    @Override
+    public void handleCommand(ChannelUID channelUID, Command command) {
+
+        try {
+            if (SinopeBindingConstants.CHANNEL_DIMMER_OUTPUTINTENSITY.equals(channelUID.getId()) && command instanceof QuantityType) {
+                setDimmerOutputIntensity(((QuantityType<?>) command).intValue());
+            }
+        } catch (IOException e) {
+            logger.debug("Cannot handle command for channel {} because of {}", channelUID.getId(),
+                    e.getLocalizedMessage());
+            this.getSinopeGatewayHandler().setCommunicationError(true);
+        }
+    }
+
+    public void setDimmerOutputIntensity(int outputIntensity) throws IOException {
+        this.getSinopeGatewayHandler().stopPoll(); // We are about to send something to gateway.
+        try {
+            if (this.getSinopeGatewayHandler().connectToBridge()) {
+                logger.debug("Connected to bridge");
+
+                SinopeDataWriteRequest req = new SinopeDataWriteRequest(this.getSinopeGatewayHandler().newSeq(), deviceId,
+                        new SinopeOutputIntensityData());
+                ((SinopeOutputIntensityData) req.getAppData()).setOutputIntensity(outputIntensity);
+
+                SinopeDataAnswer answ = (SinopeDataAnswer) this.getSinopeGatewayHandler().execute(req);
+
+                if (answ.getStatus() == DATA_ANSWER) {
+                    logger.debug("Output intensity is now: {} %%", outputIntensity);
+                } else {
+                    logger.debug("Cannot set output intensity, status: {}", answ.getStatus());
+                }
+            } else {
+                logger.debug("Could not connect to bridge to update Output Intensity");
+                updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.COMMUNICATION_ERROR, "Cannot connect to bridge");
+            }
+        } finally {
+            this.getSinopeGatewayHandler().schedulePoll();
+        }
+
+    }
+
+    @Override
+    public void bridgeStatusChanged(ThingStatusInfo bridgeStatusInfo) {
+        logger.debug("bridgeStatusChanged {}", bridgeStatusInfo);
+        updateDeviceId();
+    }
+
+    @Override
+    public void initialize() {
+        logger.debug("initializeThing thing {}", getThing().getUID());
+        updateDeviceId();
+    }
+
+    @Override
+    protected void updateConfiguration(Configuration configuration) {
+        super.updateConfiguration(configuration);
+        updateDeviceId();
+    }
+
+    public void updateDimmerOutputIntensity(int outputIntensity) {
+        updateState(SinopeBindingConstants.CHANNEL_DIMMER_OUTPUTINTENSITY, new QuantityType<>(outputIntensity, SmartHomeUnits.PERCENT));
+    }
+
+    public void update() throws IOException {
+        if (this.deviceId != null) {
+            if (isLinked(SinopeBindingConstants.CHANNEL_DIMMER_OUTPUTINTENSITY)) {
+                this.updateDimmerOutputIntensity(readOutputIntensity());
+            }
+        } else {
+            logger.error("Device id is null for Thing UID: {}", getThing().getUID());
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR);
+        }
+    }
+
+    private int readOutputIntensity() throws UnknownHostException, IOException {
+        SinopeDataReadRequest req = new SinopeDataReadRequest(this.getSinopeGatewayHandler().newSeq(), deviceId,
+                new SinopeOutputIntensityData());
+        logger.debug("Reading Output Intensity for device id: {}", ByteUtil.toString(deviceId));
+        SinopeDataAnswer answ = (SinopeDataAnswer) this.getSinopeGatewayHandler().execute(req);
+        int intensity = ((SinopeOutputIntensityData) answ.getAppData()).getOutputIntensity();
+        logger.debug("Output intensity is : {} %", intensity);
+        return intensity;
+    }
+
+    private void updateDeviceId() {
+        String sDeviceId = (String) getConfig().get(SinopeBindingConstants.CONFIG_PROPERTY_DEVICE_ID);
+        this.deviceId = SinopeConfig.convert(sDeviceId);
+        if (this.deviceId == null) {
+            logger.debug("Invalid Device id, cannot convert id: {}", sDeviceId);
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.CONFIGURATION_ERROR, "Invalid Device id");
+            return;
+        }
+        Bridge bridge = this.getBridge();
+        if (bridge == null) {
+            updateStatus(ThingStatus.OFFLINE, ThingStatusDetail.BRIDGE_OFFLINE);
+            return;
+        }
+        SinopeGatewayHandler handler = getSinopeGatewayHandler();
+        if (handler != null) {
+            handler.registerDimmerHandler(this);
+        }
+        updateStatus(ThingStatus.ONLINE);
+    }
+
+    private @Nullable SinopeGatewayHandler getSinopeGatewayHandler() {
+        Bridge bridge = this.getBridge();
+        if (bridge != null) {
+            return (SinopeGatewayHandler) bridge.getHandler();
+        } else {
+            return null;
+        }
+    }
+
+}

--- a/bundles/org.openhab.binding.sinope/src/main/java/org/openhab/binding/sinope/handler/SinopeDimmerHandler.java
+++ b/bundles/org.openhab.binding.sinope/src/main/java/org/openhab/binding/sinope/handler/SinopeDimmerHandler.java
@@ -79,7 +79,10 @@ public class SinopeDimmerHandler extends BaseThingHandler {
                 SinopeDataAnswer answ = (SinopeDataAnswer) this.getSinopeGatewayHandler().execute(req);
 
                 if (answ.getStatus() == DATA_ANSWER) {
-                    logger.debug("Output intensity is now: {} %%", outputIntensity);
+                    int answOutputIntensity = ((SinopeOutputIntensityData) answ.getAppData()).getOutputIntensity();
+                    updateDimmerOutputIntensity(outputIntensity);
+                    logger.debug("Output intensity is now: {} %%", answOutputIntensity);
+
                 } else {
                     logger.debug("Cannot set output intensity, status: {}", answ.getStatus());
                 }

--- a/bundles/org.openhab.binding.sinope/src/main/java/org/openhab/binding/sinope/handler/SinopeGatewayHandler.java
+++ b/bundles/org.openhab.binding.sinope/src/main/java/org/openhab/binding/sinope/handler/SinopeGatewayHandler.java
@@ -215,10 +215,6 @@ public class SinopeGatewayHandler extends ConfigStatusBridgeHandler {
     }
 
     public boolean registerDimmerHandler(SinopeDimmerHandler dimmerHandler) {
-        if (dimmerHandler == null) {
-            logger.error("It's not allowed to pass a null dimmerHandler.");
-            return false;
-        }
         return dimmerHandlers.add(dimmerHandler);
     }
 

--- a/bundles/org.openhab.binding.sinope/src/main/java/org/openhab/binding/sinope/handler/SinopeGatewayHandler.java
+++ b/bundles/org.openhab.binding.sinope/src/main/java/org/openhab/binding/sinope/handler/SinopeGatewayHandler.java
@@ -63,6 +63,7 @@ public class SinopeGatewayHandler extends ConfigStatusBridgeHandler {
     private @Nullable ScheduledFuture<?> pollFuture;
     private long refreshInterval; // In seconds
     private final List<SinopeThermostatHandler> thermostatHandlers = new CopyOnWriteArrayList<>();
+    private final List<SinopeDimmerHandler> dimmerHandlers = new CopyOnWriteArrayList<>();
     private int seq = 1;
     private @Nullable Socket clientSocket;
     private boolean searching; // In searching mode..
@@ -133,13 +134,17 @@ public class SinopeGatewayHandler extends ConfigStatusBridgeHandler {
     }
 
     private synchronized void poll() {
-        if (thermostatHandlers.size() > 0) {
+        if (thermostatHandlers.size() > 0 || dimmerHandlers.size() > 0) {
             logger.debug("Polling for state");
             try {
                 if (connectToBridge()) {
                     logger.debug("Connected to bridge");
                     for (SinopeThermostatHandler sinopeThermostatHandler : thermostatHandlers) {
                         sinopeThermostatHandler.update();
+                    }
+
+                    for (SinopeDimmerHandler sinopeDimmerHandler : dimmerHandlers) {
+                        sinopeDimmerHandler.update();
                     }
                 }
             } catch (IOException e) {
@@ -207,6 +212,18 @@ public class SinopeGatewayHandler extends ConfigStatusBridgeHandler {
 
     public boolean unregisterThermostatHandler(SinopeThermostatHandler thermostatHandler) {
         return thermostatHandlers.remove(thermostatHandler);
+    }
+
+    public boolean registerDimmerHandler(SinopeDimmerHandler dimmerHandler) {
+        if (dimmerHandler == null) {
+            logger.error("It's not allowed to pass a null dimmerHandler.");
+            return false;
+        }
+        return dimmerHandlers.add(dimmerHandler);
+    }
+
+    public boolean unregisterDimmerHandler(SinopeThermostatHandler dimmerHandler) {
+        return dimmerHandlers.remove(dimmerHandler);
     }
 
     @Override

--- a/bundles/org.openhab.binding.sinope/src/main/java/org/openhab/binding/sinope/internal/SinopeHandlerFactory.java
+++ b/bundles/org.openhab.binding.sinope/src/main/java/org/openhab/binding/sinope/internal/SinopeHandlerFactory.java
@@ -26,6 +26,7 @@ import org.eclipse.smarthome.core.thing.binding.BaseThingHandlerFactory;
 import org.eclipse.smarthome.core.thing.binding.ThingHandler;
 import org.eclipse.smarthome.core.thing.binding.ThingHandlerFactory;
 import org.openhab.binding.sinope.SinopeBindingConstants;
+import org.openhab.binding.sinope.handler.SinopeDimmerHandler;
 import org.openhab.binding.sinope.handler.SinopeGatewayHandler;
 import org.openhab.binding.sinope.handler.SinopeThermostatHandler;
 import org.openhab.binding.sinope.internal.discovery.SinopeThingsDiscoveryService;
@@ -58,6 +59,8 @@ public class SinopeHandlerFactory extends BaseThingHandlerFactory {
             return bridge;
         } else if (SinopeBindingConstants.THING_TYPE_THERMO.equals(thingTypeUID)) {
             return new SinopeThermostatHandler(thing);
+        } else if (SinopeBindingConstants.THING_TYPE_DIMMER.equals(thingTypeUID)) {
+            return new SinopeDimmerHandler(thing);
         }
         return null;
     }

--- a/bundles/org.openhab.binding.sinope/src/main/java/org/openhab/binding/sinope/internal/core/appdata/SinopeLightModeData.java
+++ b/bundles/org.openhab.binding.sinope/src/main/java/org/openhab/binding/sinope/internal/core/appdata/SinopeLightModeData.java
@@ -18,27 +18,27 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
 /**
- * The Class SinopeOutputIntensityData.
+ * The Class SinopeLightModeData.
  *
  * @author Christos Karras - Initial contribution
  */
 @NonNullByDefault
-public class SinopeOutputIntensityData extends SinopeAppData {
+public class SinopeLightModeData extends SinopeAppData {
 
     /**
      * Instantiates a new sinope set point temp data.
      */
-    public SinopeOutputIntensityData() {
+    public SinopeLightModeData() {
 
-        super(new byte[] { 0x00, 0x00, 0x10, 0x00 }, new byte[] { 0, 0 });
+        super(new byte[] { 0x00, 0x00, 0x10, 0x09 }, new byte[] { 0, 0 });
     }
 
     /**
-     * Gets the dimmer output intensity.
+     * Gets the light mode
      *
-     * @return the dimmer outut intensity (0-100)
+     * @return the light mode: 1 = Manual (Hold), 2 = Auto (Schedule), 3 = Random (simulation of presence), 130 = Bypass Auto (Temporary hold until next scheduled period)
      */
-    public int getOutputIntensity() {
+    public int getLightMode() {
         if (getData() != null) {
             ByteBuffer bb = ByteBuffer.wrap(getData());
             bb.order(ByteOrder.LITTLE_ENDIAN);
@@ -55,15 +55,15 @@ public class SinopeOutputIntensityData extends SinopeAppData {
         StringBuilder sb = new StringBuilder();
         sb.append(super.toString());
         if (getData() != null) {
-            sb.append(String.format("\nOutput intensity %d %%", this.getOutputIntensity()));
+            sb.append(String.format("\nLight mode %d", this.getLightMode()));
         }
         return sb.toString();
     }
 
-    public void setOutputIntensity(int newOutputIntensity) {
+    public void setLightMode(int newLightMode) {
         ByteBuffer bb = ByteBuffer.wrap(getData());
         bb.order(ByteOrder.LITTLE_ENDIAN);
-        bb.put((byte) (newOutputIntensity & 0xFF));
+        bb.put((byte) (newLightMode & 0xFF));
     }
 
 }

--- a/bundles/org.openhab.binding.sinope/src/main/java/org/openhab/binding/sinope/internal/core/appdata/SinopeOutputIntensityData.java
+++ b/bundles/org.openhab.binding.sinope/src/main/java/org/openhab/binding/sinope/internal/core/appdata/SinopeOutputIntensityData.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.sinope.internal.core.appdata;
+
+import org.eclipse.jdt.annotation.NonNullByDefault;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+/**
+ * The Class SinopeRoomTempData.
+ *
+ * @author Christos Karras - Initial contribution
+ */
+@NonNullByDefault
+public class SinopeOutputIntensityData extends SinopeAppData {
+
+    /**
+     * Instantiates a new sinope set point temp data.
+     */
+    public SinopeOutputIntensityData() {
+
+        super(new byte[] { 0x00, 0x00, 0x10, 0x00 }, new byte[] { 0, 0 });
+    }
+
+    /**
+     * Gets the dimmer output intensity.
+     *
+     * @return the dimmer outut intensity (0-100)
+     */
+    public int getOutputIntensity() {
+        if (getData() != null) {
+            ByteBuffer bb = ByteBuffer.wrap(getData());
+            bb.order(ByteOrder.LITTLE_ENDIAN);
+            return (int)(bb.get()) & 0xFF;
+        }
+        return 0;
+    }
+
+    /**
+     * @see SinopeAppData#toString()
+     */
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(super.toString());
+        if (getData() != null) {
+            sb.append(String.format("\nOutput intensity %d %%", this.getOutputIntensity()));
+        }
+        return sb.toString();
+    }
+
+    public void setOutputIntensity(int newOutputIntensity) {
+        ByteBuffer bb = ByteBuffer.wrap(getData());
+        bb.order(ByteOrder.LITTLE_ENDIAN);
+        bb.put((byte) (newOutputIntensity & 0xFF));
+    }
+
+}

--- a/bundles/org.openhab.binding.sinope/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.sinope/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -64,7 +64,6 @@
 		<description>Sinopé Dimmer control</description>
 		<channels>
 			<channel id="dimmerOutputIntensity" typeId="dimmerOutputIntensity" />
-			<channel id="lightMode" typeId="dimmerLightMode" />
 		</channels>
 		<config-description>
 			<parameter name="deviceId" type="text" required="true">
@@ -131,21 +130,6 @@
 		<description>Output Intensity</description>
 		<category>Light</category>
 		<state min="0" max="100" step="1" pattern="%d %%" readOnly="false" />
-	</channel-type>
-
-	<channel-type id="dimmerLightMode">
-		<item-type>Number</item-type>
-		<label>Dimmer Light Mode</label>
-		<description>Dimmer Light mode</description>
-		<category>Light</category>
-		<state pattern="%s" readOnly="false">
-			<options>
-				<option value="1">Manual (Hold)</option>
-				<option value="2">Auto (Schedule)</option>
-				<option value="3">Random (Simulation of presence)</option>
-				<option value="130">Bypass Auto (Temporary hold until the next scheduled period)</option>
-			</options>
-		</state>
 	</channel-type>
 
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.sinope/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.sinope/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -64,6 +64,7 @@
 		<description>Sinopé Dimmer control</description>
 		<channels>
 			<channel id="dimmerOutputIntensity" typeId="dimmerOutputIntensity" />
+			<channel id="lightMode" typeId="lightMode" />
 		</channels>
 		<config-description>
 			<parameter name="deviceId" type="text" required="true">
@@ -130,6 +131,21 @@
 		<description>Output Intensity</description>
 		<category>Light</category>
 		<state min="0" max="100" step="1" pattern="%d %%" readOnly="false" />
+	</channel-type>
+
+	<channel-type id="lightMode">
+		<item-type>Number</item-type>
+		<label>Dimmer Light Mode</label>
+		<description>Dimmer Light mode</description>
+		<category>Light</category>
+		<state pattern="%s" readOnly="false">
+			<options>
+				<option value="1">Manual (Hold)</option>
+				<option value="2">Auto (Schedule)</option>
+				<option value="3">Random (Simulation of presence)</option>
+				<option value="130">Bypass Auto (Temporary hold until the next scheduled period)</option>
+			</options>
+		</state>
 	</channel-type>
 
 </thing:thing-descriptions>

--- a/bundles/org.openhab.binding.sinope/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.sinope/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -56,6 +56,23 @@
 		</config-description>
 	</thing-type>
 
+	<thing-type id="dimmer">
+		<supported-bridge-type-refs>
+			<bridge-type-ref id="gateway" />
+		</supported-bridge-type-refs>
+		<label>Sinopé Dimmer</label>
+		<description>Sinopé Dimmer control</description>
+		<channels>
+			<channel id="dimmerOutputIntensity" typeId="dimmerOutputIntensity" />
+			<channel id="lightMode" typeId="dimmerLightMode" />
+		</channels>
+		<config-description>
+			<parameter name="deviceId" type="text" required="true">
+				<label>Dimmer device ID</label>
+			</parameter>
+		</config-description>
+	</thing-type>
+
 	<channel-type id="insideTemperature">
 		<item-type>Number:Temperature</item-type>
 		<label>Temperature</label>
@@ -107,4 +124,28 @@
 		<category>Heating</category>
 		<state min="0" max="100" step="1" pattern="%d %%" readOnly="true" />
 	</channel-type>
+
+	<channel-type id="dimmerOutputIntensity">
+		<item-type>Number:Dimensionless</item-type>
+		<label>Output Intensity</label>
+		<description>Output Intensity</description>
+		<category>Light</category>
+		<state min="0" max="100" step="1" pattern="%d %%" readOnly="false" />
+	</channel-type>
+
+	<channel-type id="dimmerLightMode">
+		<item-type>Number</item-type>
+		<label>Dimmer Light Mode</label>
+		<description>Dimmer Light mode</description>
+		<category>Light</category>
+		<state pattern="%s" readOnly="false">
+			<options>
+				<option value="1">Manual (Hold)</option>
+				<option value="2">Auto (Schedule)</option>
+				<option value="3">Random (Simulation of presence)</option>
+				<option value="130">Bypass Auto (Temporary hold until the next scheduled period)</option>
+			</options>
+		</state>
+	</channel-type>
+
 </thing:thing-descriptions>


### PR DESCRIPTION
<!-- TITLE -->
Added support for Sinope DM2500RF dimmer and SW2500RF switch

<!-- DESCRIPTION -->
Added support for a new Sinope thing type: Dimmer. This can be used both for dimmer and switches. A switch follows the same protocol as the dimmer but its output intensity values are limited to 0 (OFF) and 1 (ON)

The implementation is similar to the one used for thermostat. However, note that after every successful request, the dimmer's outputIntensity or lightMode are updated immediately to OpenHAB, from the contents of the GT125 response, instead of waiting for the next pool to update them. (But they are also updated by polling at the configured polling interval)